### PR TITLE
Switch from pycryptodome to pycryptodomex

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ autobahn
 twisted
 jarbas_utils>=0.5.1
 json_database
-pycryptodome
+pycryptodomex
 upnpclient>=0.0.8
 zeroconf>=0.1.6

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
                       "twisted",
                       "jarbas_utils>=0.5.0",
                       "json_database",
-                      "pycryptodome",
+                      "pycryptodomex",
                       "upnpclient>=0.0.8"],
     url='https://github.com/JarbasAl/hive_mind',
     license='MIT',


### PR DESCRIPTION
pycryptodome is for / with backwards compatibility with the no longer mainainted pycrypto, the X is for the next version from the same developers.

As HiveMind-core does not need any pycrypto backwards compatibility using pycryptodome pycryptodomex is maybe prefered. It has no influence other then the installed location of the package. Hence it even uses the exact same pacjage files, yet pycryptodomex is the "new way to go" (No clue what the future will bring, I guess at some point pycryptodome is also no longer supported)